### PR TITLE
Fix: Added required BaseCombatStat field for red_panda

### DIFF
--- a/source/guides/red_panda.rst
+++ b/source/guides/red_panda.rst
@@ -79,7 +79,14 @@ Let's implement it with an underscore property:
 			"AttackDamage": 3,
 			"AttackSpeed": 1,
 			"Defence": 1,
-			"HitChance": 0.9
+			"HitChance": 0.9,
+			"SpecialHits": [
+				{
+					"Chance": 0.1,
+					"HitType": "Poison",
+					"Target":  "Target"
+				}
+			]
 		}
 	}
 


### PR DESCRIPTION
## Changes:

Added required `CombatStat` field `SpecialHits` to tutorial for Red panda to avoid confusion.

Notes:
- Not sure if we should have an empty array there or not, i can definitely change the `SpecialHit` to be something more appropriate to a red panda :)